### PR TITLE
Optimize SlopeAngle, precalculate the bit shifting onto the IDivTable.

### DIFF
--- a/source/maputl.c
+++ b/source/maputl.c
@@ -14,7 +14,7 @@ angle_t SlopeAngle(LongWord num,LongWord den)
 	num>>=(FRACBITS-3);			/* Leave in 3 extra bits for just a little more precision */
 	den>>=FRACBITS;				/* Must be an int */
 
-	num = num*(IDivTable[den]>>9);	/* Perform the divide using a recipocal mul */
+	num = num*(IDivTable[den]);	/* Perform the divide using a recipocal mul */
 	num>>=((FRACBITS+3)-SLOPEBITS);	/* Isolate the fraction for index to the angle table */
 
 	if (num>SLOPERANGE) {			/* Out of range? */

--- a/source/rdata.c
+++ b/source/rdata.c
@@ -111,10 +111,10 @@ void R_InitData(void)
 
 **********************************/
 
-	IDivTable[0] = -1;
+	IDivTable[0] = -1 >> 9;
 	i = 1;
 	do {
-		IDivTable[i] = IMFixDiv(512<<FRACBITS,i<<FRACBITS);		/* 512.0 / i */
+		IDivTable[i] = IMFixDiv(512<<FRACBITS,i<<FRACBITS) >> 9;		/* 512.0 / i */
 	} while (++i<(sizeof(IDivTable)/sizeof(Word)));
 	InitMathTables();
 }


### PR DESCRIPTION
SlopeAngle is heavily used in Doom (more than 440.000 calls in a single timedemo), any optimization to it makes the rendering process run faster.